### PR TITLE
rebuild piano in PixiJS + Tone.js with MIDI-ready 2D polyphony 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
       "name": "pianopixi",
       "version": "0.0.0",
       "dependencies": {
-        "pixi.js": "^8.8.1"
+        "pixi.js": "^8.8.1",
+        "tone": "^15.1.22"
       },
       "devDependencies": {
         "@eslint/js": "^9.21.0",
@@ -19,6 +20,15 @@
         "typescript": "~5.7.3",
         "typescript-eslint": "^8.25.0",
         "vite": "^6.2.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.27.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
+      "integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1364,6 +1374,19 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/automation-events": {
+      "version": "7.1.11",
+      "resolved": "https://registry.npmjs.org/automation-events/-/automation-events-7.1.11.tgz",
+      "integrity": "sha512-TnclbJ0482ydRenzrR9FIbqalHScBBdQTIXv8tVunhYx8dq7E0Eq5v5CSAo67YmLXNbx5jCstHcLZDJ33iONDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.6",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18.2.0"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -2557,6 +2580,17 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/standardized-audio-context": {
+      "version": "25.3.77",
+      "resolved": "https://registry.npmjs.org/standardized-audio-context/-/standardized-audio-context-25.3.77.tgz",
+      "integrity": "sha512-Ki9zNz6pKcC5Pi+QPjPyVsD9GwJIJWgryji0XL9cAJXMGyn+dPOf6Qik1AHei0+UNVcc4BOCa0hWLBzlwqsW/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.25.6",
+        "automation-events": "^7.0.9",
+        "tslib": "^2.7.0"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -2657,6 +2691,16 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tone": {
+      "version": "15.1.22",
+      "resolved": "https://registry.npmjs.org/tone/-/tone-15.1.22.tgz",
+      "integrity": "sha512-TCScAGD4sLsama5DjvTUXlLDXSqPealhL64nsdV1hhr6frPWve0DeSo63AKnSJwgfg55fhvxj0iPPRwPN5o0ag==",
+      "license": "MIT",
+      "dependencies": {
+        "standardized-audio-context": "^25.3.70",
+        "tslib": "^2.3.1"
+      }
+    },
     "node_modules/ts-api-utils": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
@@ -2669,6 +2713,12 @@
       "peerDependencies": {
         "typescript": ">=4.8.4"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "dev": "vite"
   },
   "dependencies": {
-    "pixi.js": "^8.8.1"
+    "pixi.js": "^8.8.1",
+    "tone": "^15.1.22"
   },
   "devDependencies": {
     "@eslint/js": "^9.21.0",

--- a/src/main.ts
+++ b/src/main.ts
@@ -146,14 +146,14 @@ import * as Tone from "tone";
 
   // MIDI + Tone.js
   async function setupMidiAndTone() {
-    // Inicializa Tone.js (necesario para que suene en navegadores modernos)
     await Tone.start();
 
-    // Crea un sintetizador simple
-    const synth = new Tone.Synth().toDestination();
-    let currentPitchBend = 0; // Guarda el valor actual de pitch bend
+    // Usa PolySynth para acordes y varias notas a la vez
+    const synth = new Tone.PolySynth(Tone.Synth).toDestination();
+    const distortion = new Tone.Distortion(0).toDestination();
+    synth.connect(distortion);
+    let currentPitchBend = 0;
 
-    // Solicita acceso a MIDI
     if (navigator.requestMIDIAccess) {
       navigator.requestMIDIAccess().then((midiAccess) => {
         for (const input of midiAccess.inputs.values()) {
@@ -162,21 +162,16 @@ import * as Tone from "tone";
 
             // PITCH BEND
             if (status === 224) {
-              // data1 = LSB, data2 = MSB
-              const value = (data2 << 7) | data1; // 14 bits
-              // MIDI pitch bend va de 0 (min) a 8192 (center) a 16383 (max)
-              // Normaliza a rango -1 a 1
+              const value = (data2 << 7) | data1;
               const bend = (value - 8192) / 8192;
               currentPitchBend = bend;
-              // Detune en cents: +/- 2 semitonos (200 cents) es típico
-              synth.detune.value = bend * 200;
+              synth.set({ detune: bend * 200 });
             }
 
             // NOTE ON
             if (status === 144 && data2 > 0) {
               const noteName = Tone.Frequency(data1, "midi").toNote();
               synth.triggerAttack(noteName);
-              // Resalta la tecla visual
               const key = midiNoteToKey[data1];
               if (key && typeof key.draw === "function") {
                 // @ts-ignore
@@ -188,7 +183,8 @@ import * as Tone from "tone";
 
             // NOTE OFF
             if ((status === 128) || (status === 144 && data2 === 0)) {
-              synth.triggerRelease();
+              const noteName = Tone.Frequency(data1, "midi").toNote();
+              synth.triggerRelease(noteName);
               const key = midiNoteToKey[data1];
               if (key && typeof key.draw === "function") {
                 // @ts-ignore
@@ -196,6 +192,14 @@ import * as Tone from "tone";
                 // @ts-ignore
                 key.isActive = false;
               }
+            }
+
+            // CONTROL CHANGE (Mod Wheel)
+            if (status === 176 && data1 === 1) {
+              const modValue = data2 / 127;
+              // Ejemplo: controla volumen, distorsión y puedes agregar más
+              synth.volume.value = -12 + modValue * 12; // de -12dB a 0dB
+              distortion.distortion = modValue; // 0 a 1
             }
           };
         }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,35 +1,224 @@
-import { Application, Assets, Sprite } from "pixi.js";
+import { Application, Graphics, Container } from "pixi.js";
+import * as Tone from "tone";
 
 (async () => {
-  // Create a new application
+  // Crear la aplicación
   const app = new Application();
-
-  // Initialize the application
   await app.init({ background: "#1099bb", resizeTo: window });
-
-  // Append the application canvas to the document body
   document.getElementById("pixi-container")!.appendChild(app.canvas);
 
-  // Load the bunny texture
-  const texture = await Assets.load("/assets/bunny.png");
+  // Parámetros del piano
+  const octaves = 2;
+  const whiteNotes = ["C", "D", "E", "F", "G", "A", "B"];
+  const blackNotes = ["C#", "D#", "", "F#", "G#", "A#", ""];
 
-  // Create a bunny Sprite
-  const bunny = new Sprite(texture);
+  // Calcula el ancho de cada tecla para ocupar todo el width
+  const totalWhiteKeys = octaves * whiteNotes.length;
+  const whiteKeyWidth = app.screen.width / totalWhiteKeys;
+  const whiteKeyHeight = whiteKeyWidth * 4.2; // Relación de aspecto piano clásico
+  const blackKeyWidth = whiteKeyWidth * 0.6;
+  const blackKeyHeight = whiteKeyHeight * 0.6;
 
-  // Center the sprite's anchor point
-  bunny.anchor.set(0.5);
+  // Piano alineado arriba a la izquierda
+  const pianoOffsetX = 0;
+  const pianoOffsetY = 0;
 
-  // Move the sprite to the center of the screen
-  bunny.position.set(app.screen.width / 2, app.screen.height / 2);
+  const piano = new Container();
 
-  // Add the bunny to the stage
-  app.stage.addChild(bunny);
+  // Helper para interacción
+  function makeKeyInteractive(
+    key: Graphics,
+    baseColor: number,
+    hoverColor: number,
+    activeColor: number,
+    width: number,
+    height: number,
+    stroke: boolean = false
+  ) {
+    key.eventMode = "static";
+    key.cursor = "pointer";
+    // Guarda el color base y el estado activo en la instancia
+    // @ts-ignore
+    key.baseColor = baseColor;
+    // @ts-ignore
+    key.isActive = false;
+    // @ts-ignore
+    key.draw = (color: number) => {
+      key.clear();
+      key.rect(0, 0, width, height);
+      key.fill({ color });
+      if (stroke) key.stroke({ color: 0x000000, width: 2 });
+    };
 
-  // Listen for animate update
-  app.ticker.add((time) => {
-    // Just for fun, let's rotate mr rabbit a little.
-    // * Delta is 1 if running at 100% performance *
-    // * Creates frame-independent transformation *
-    bunny.rotation += 0.1 * time.deltaTime;
-  });
+    key.on("pointerover", () => {
+      // @ts-ignore
+      if (!key.isActive) key.draw(hoverColor);
+    });
+    key.on("pointerout", () => {
+      // @ts-ignore
+      if (!key.isActive) key.draw(baseColor);
+    });
+    key.on("pointerdown", () => {
+      // @ts-ignore
+      key.isActive = true;
+      // @ts-ignore
+      key.draw(activeColor);
+    });
+    key.on("pointerup", () => {
+      // @ts-ignore
+      key.isActive = false;
+      // @ts-ignore
+      key.draw(hoverColor);
+    });
+    key.on("pointerupoutside", () => {
+      // @ts-ignore
+      key.isActive = false;
+      // @ts-ignore
+      key.draw(baseColor);
+    });
+  }
+
+  // Mapeo de teclas MIDI a objetos visuales
+  const midiNoteToKey: Record<number, Graphics> = {};
+
+  // Utilidad para obtener el número MIDI de una nota y octava
+  function getMidiNumber(note: string, octave: number) {
+    // C4 = 60, C#4 = 61, D4 = 62, etc.
+    return Tone.Frequency(`${note}${octave + 3}`).toMidi(); // octave+3 porque octave=1 es C1=24
+  }
+
+  // Dibuja teclas blancas
+  for (let octave = 0; octave < octaves; octave++) {
+    for (let i = 0; i < whiteNotes.length; i++) {
+      const note = whiteNotes[i];
+      const midi = getMidiNumber(note, octave);
+      const key = new Graphics();
+      key.rect(0, 0, whiteKeyWidth, whiteKeyHeight);
+      key.fill({ color: 0xffffff });
+      key.stroke({ color: 0x000000, width: 2 });
+      key.x = (octave * whiteNotes.length + i) * whiteKeyWidth;
+      key.y = 0;
+      makeKeyInteractive(
+        key,
+        0xffffff,
+        0xdddddd,
+        0xffeb3b,
+        whiteKeyWidth,
+        whiteKeyHeight,
+        true
+      );
+      piano.addChild(key);
+      midiNoteToKey[midi] = key;
+    }
+  }
+
+  // Dibuja teclas negras
+  for (let octave = 0; octave < octaves; octave++) {
+    for (let i = 0; i < blackNotes.length; i++) {
+      if (blackNotes[i] === "") continue;
+      const note = blackNotes[i];
+      const midi = getMidiNumber(note, octave);
+      const key = new Graphics();
+      key.rect(0, 0, blackKeyWidth, blackKeyHeight);
+      key.fill({ color: 0x000000 });
+      key.x =
+        (octave * whiteNotes.length + i) * whiteKeyWidth +
+        whiteKeyWidth - blackKeyWidth / 2;
+      key.y = 0;
+      makeKeyInteractive(
+        key,
+        0x000000,
+        0x444444,
+        0xffeb3b,
+        blackKeyWidth,
+        blackKeyHeight,
+        false
+      );
+      piano.addChild(key);
+      midiNoteToKey[midi] = key;
+    }
+  }
+
+  piano.x = pianoOffsetX;
+  piano.y = pianoOffsetY;
+
+  app.stage.addChild(piano);
+
+  // MIDI + Tone.js
+  async function setupMidiAndTone() {
+    // Inicializa Tone.js (necesario para que suene en navegadores modernos)
+    await Tone.start();
+
+    // Crea un sintetizador simple
+    const synth = new Tone.Synth().toDestination();
+
+    // Solicita acceso a MIDI
+    if (navigator.requestMIDIAccess) {
+      navigator.requestMIDIAccess().then((midiAccess) => {
+        for (const input of midiAccess.inputs.values()) {
+          input.onmidimessage = (msg) => {
+            const [status, note, velocity] = msg.data;
+            // Nota ON
+            if (status === 144 && velocity > 0) {
+              const noteName = Tone.Frequency(note, "midi").toNote();
+              synth.triggerAttack(noteName);
+
+              // Resalta la tecla visual
+              const key = midiNoteToKey[note];
+              if (key) {
+                // Usa la función draw del helper para mantener consistencia
+                // @ts-ignore
+                if (typeof key.draw === "function") {
+                  // @ts-ignore
+                  key.draw(0xffeb3b); // Amarillo
+                  // Marca como activa para evitar que el mouse la sobrescriba
+                  // @ts-ignore
+                  key.isActive = true;
+                } else {
+                  // Fallback por si no existe draw (no debería pasar)
+                  key.clear();
+                  if (key.height === whiteKeyHeight) {
+                    key.rect(0, 0, whiteKeyWidth, whiteKeyHeight);
+                    key.fill({ color: 0xffeb3b });
+                    key.stroke({ color: 0x000000, width: 2 });
+                  } else {
+                    key.rect(0, 0, blackKeyWidth, blackKeyHeight);
+                    key.fill({ color: 0xffeb3b });
+                  }
+                }
+              }
+            }
+            // Nota OFF
+            if ((status === 128) || (status === 144 && velocity === 0)) {
+              synth.triggerRelease();
+              const key = midiNoteToKey[note];
+              if (key) {
+                // @ts-ignore
+                if (typeof key.draw === "function") {
+                  // @ts-ignore
+                  key.draw(key.baseColor); // Restaura color base
+                  // @ts-ignore
+                  key.isActive = false;
+                } else {
+                  key.clear();
+                  if (key.height === whiteKeyHeight) {
+                    key.rect(0, 0, whiteKeyWidth, whiteKeyHeight);
+                    key.fill({ color: 0xffffff });
+                    key.stroke({ color: 0x000000, width: 2 });
+                  } else {
+                    key.rect(0, 0, blackKeyWidth, blackKeyHeight);
+                    key.fill({ color: 0x000000 });
+                  }
+                }
+              }
+            }
+          };
+        }
+      });
+    } else {
+      console.warn("Web MIDI API no soportada en este navegador.");
+    }
+  }
+
+  setupMidiAndTone();
 })();

--- a/src/main.ts
+++ b/src/main.ts
@@ -151,65 +151,50 @@ import * as Tone from "tone";
 
     // Crea un sintetizador simple
     const synth = new Tone.Synth().toDestination();
+    let currentPitchBend = 0; // Guarda el valor actual de pitch bend
 
     // Solicita acceso a MIDI
     if (navigator.requestMIDIAccess) {
       navigator.requestMIDIAccess().then((midiAccess) => {
         for (const input of midiAccess.inputs.values()) {
           input.onmidimessage = (msg) => {
-            const [status, note, velocity] = msg.data;
-            // Nota ON
-            if (status === 144 && velocity > 0) {
-              const noteName = Tone.Frequency(note, "midi").toNote();
-              synth.triggerAttack(noteName);
+            const [status, data1, data2] = msg.data;
 
+            // PITCH BEND
+            if (status === 224) {
+              // data1 = LSB, data2 = MSB
+              const value = (data2 << 7) | data1; // 14 bits
+              // MIDI pitch bend va de 0 (min) a 8192 (center) a 16383 (max)
+              // Normaliza a rango -1 a 1
+              const bend = (value - 8192) / 8192;
+              currentPitchBend = bend;
+              // Detune en cents: +/- 2 semitonos (200 cents) es típico
+              synth.detune.value = bend * 200;
+            }
+
+            // NOTE ON
+            if (status === 144 && data2 > 0) {
+              const noteName = Tone.Frequency(data1, "midi").toNote();
+              synth.triggerAttack(noteName);
               // Resalta la tecla visual
-              const key = midiNoteToKey[note];
-              if (key) {
-                // Usa la función draw del helper para mantener consistencia
+              const key = midiNoteToKey[data1];
+              if (key && typeof key.draw === "function") {
                 // @ts-ignore
-                if (typeof key.draw === "function") {
-                  // @ts-ignore
-                  key.draw(0xffeb3b); // Amarillo
-                  // Marca como activa para evitar que el mouse la sobrescriba
-                  // @ts-ignore
-                  key.isActive = true;
-                } else {
-                  // Fallback por si no existe draw (no debería pasar)
-                  key.clear();
-                  if (key.height === whiteKeyHeight) {
-                    key.rect(0, 0, whiteKeyWidth, whiteKeyHeight);
-                    key.fill({ color: 0xffeb3b });
-                    key.stroke({ color: 0x000000, width: 2 });
-                  } else {
-                    key.rect(0, 0, blackKeyWidth, blackKeyHeight);
-                    key.fill({ color: 0xffeb3b });
-                  }
-                }
+                key.draw(0xffeb3b);
+                // @ts-ignore
+                key.isActive = true;
               }
             }
-            // Nota OFF
-            if ((status === 128) || (status === 144 && velocity === 0)) {
+
+            // NOTE OFF
+            if ((status === 128) || (status === 144 && data2 === 0)) {
               synth.triggerRelease();
-              const key = midiNoteToKey[note];
-              if (key) {
+              const key = midiNoteToKey[data1];
+              if (key && typeof key.draw === "function") {
                 // @ts-ignore
-                if (typeof key.draw === "function") {
-                  // @ts-ignore
-                  key.draw(key.baseColor); // Restaura color base
-                  // @ts-ignore
-                  key.isActive = false;
-                } else {
-                  key.clear();
-                  if (key.height === whiteKeyHeight) {
-                    key.rect(0, 0, whiteKeyWidth, whiteKeyHeight);
-                    key.fill({ color: 0xffffff });
-                    key.stroke({ color: 0x000000, width: 2 });
-                  } else {
-                    key.rect(0, 0, blackKeyWidth, blackKeyHeight);
-                    key.fill({ color: 0x000000 });
-                  }
-                }
+                key.draw(key.baseColor);
+                // @ts-ignore
+                key.isActive = false;
               }
             }
           };
@@ -220,5 +205,21 @@ import * as Tone from "tone";
     }
   }
 
-  setupMidiAndTone();
+  // Crea el botón si no existe
+  let audioBtn = document.getElementById("audio-btn");
+  if (!audioBtn) {
+    audioBtn = document.createElement("button");
+    audioBtn.id = "audio-btn";
+    audioBtn.textContent = "Activar audio y MIDI";
+    audioBtn.style.position = "absolute";
+    audioBtn.style.top = "10px";
+    audioBtn.style.left = "10px";
+    audioBtn.style.zIndex = "1000";
+    document.body.appendChild(audioBtn);
+  }
+
+  audioBtn.addEventListener("click", async () => {
+    await setupMidiAndTone();
+    audioBtn.remove(); // Quita el botón tras activar audio
+  });
 })();

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,100 @@
+import * as Tone from "tone";
+export const OCTAVES_RANGE = [1, 2, 3, 4, 5, 6, 7] as const;
+export const BASE_NOTES = [
+  'C', 'D', 'E', 'F', 'G', 'A', 'B'
+] as const;
+export const NOTES = [
+  'Ab', 'A', 'A#', 'Bb', 'B', 'B#', 'Cb', 'C', 'C#', 'Db',
+  'D', 'D#', 'Eb', 'E', 'E#', 'Fb', 'F', 'F#', 'Gb', 'G', 'G#'
+] as const;
+export const SHARP_TO_FLAT_MAP: Partial<Record<tNoteName, tNoteName>> = {
+  "C#": "Db",
+  "D#": "Eb",
+  "F#": "Gb",
+  "G#": "Ab",
+  "A#": "Bb"
+};
+export const CHORD_QUALITIES = [
+  'maj', 'min', 'dim', 'aug',
+  'sus2', 'sus4',
+  'maj7', 'm7', 'dom7',
+  'maj9', 'm9', 'dom9',
+  'maj11', 'm11', 'dom11',
+  'maj13', 'm13', 'dom13'
+] as const;
+export const MODES = [
+  'ionian', 'dorian', 'phrygian',
+  'lydian', 'mixolydian', 'aeolian',
+  'locrian'
+] as const;
+
+export type tOctaveRange = typeof OCTAVES_RANGE[number]; // example: 1, 2, 3, 4, 5
+export type tChordQualities = typeof CHORD_QUALITIES[number]; // "maj", "min", "dim", etc.
+
+export type tMode = typeof MODES[number]; // example: "ionian", "dorian", etc.
+export type tNote = typeof BASE_NOTES[number]; // example: "C", "D", "E", etc.
+export type tNoteName = typeof NOTES[number]; // example: "C", "Db", "E#", etc.
+export type tNoteWithOctave = `${tNoteName}${tOctaveRange}`; // example: "C4", "D#5", "Bb3", etc.
+export type tNoteWQuality = `${tNoteName}${tChordQualities}`; // example: "Cmaj", "Dmin", "E#sus4", etc.
+export type tNoteWOCtaveQuality = `${tNoteName}${tOctaveRange}${tChordQualities}`; // example: "C3maj", "Dmin", "E#sus4", etc.
+export type tPercentString = `${number}%`; // example: "7.5%"
+export type tTime = Tone.Unit.Time; // example: "4n", "2m", "1:2:3", etc.
+
+export type tChord = tNoteWithOctave[]
+export type tChordSequence = tChord[]
+
+export type tChordWithName = {
+  id: string; // note+type 
+  quality: tChordQualities, // Ejemplo: "maj", "min", "sus4", etc.
+  rootNote: tNoteName, // Ejemplo: "C", "D#", "E#", etc.
+  name: string; // baseNoteName+type Ej: "Cmaj", "Dmin", "E#sus4"
+  displayNotes: string; // Ej: "C E G"; 
+  chord: tChord; // notas en logica completa para piano
+}
+
+export type tChordMap = Record<string, tNoteWithOctave[]>;
+
+export type tPianoNotes = {
+  white: tNoteWithOctave[];
+  black: tNoteWithOctave[];
+};
+
+export type tSequenceToPlayProps = {
+  sequenceToPlay: tChordSequence;
+  onSequenceEnd: () => void;
+  highlightedKeys?: boolean;
+}
+
+export const CHORD_INTERVALS: Record<tChordQualities, number[]> = {
+  // casa posición del array representa 
+  // la cantidad de semitonos desde la tónica
+  maj: [0, 4, 7],
+  min: [0, 3, 7],
+  dim: [0, 3, 6],
+  aug: [0, 4, 8],
+  sus2: [0, 2, 7],
+  sus4: [0, 5, 7],
+  maj7: [0, 4, 7, 11],
+  m7: [0, 3, 7, 10],
+  dom7: [0, 4, 7, 10],
+  maj9: [0, 4, 7, 11, 14],
+  m9: [0, 3, 7, 10, 14],
+  dom9: [0, 4, 7, 10, 14],
+  maj11: [0, 4, 7, 11, 14, 17],
+  m11: [0, 3, 7, 10, 14, 17],
+  dom11: [0, 4, 7, 10, 14, 17],
+  maj13: [0, 4, 7, 11, 14, 17, 21],
+  m13: [0, 3, 7, 10, 14, 17, 21],
+  dom13: [0, 4, 7, 10, 14, 17, 21],
+};
+
+export interface iChordEvent {
+  pitches: tChord;
+  time: string;           // Tiempo musical (ej: "0:0:1", "1m", "4n")
+  duration: tTime;
+  velocity?: number;
+  highlightGroup?: 1 | 2;
+  scheduledPlayTime?: number;
+}
+
+export type tMelodySequence = iChordEvent[];


### PR DESCRIPTION
A quick experiment comparing ReactJS and PixiJS for building interactive UIs.

After spending 15 days on a complex, re-render-heavy interface in React, I rebuilt the core logic using PixiJS in just 30 minutes.

The result? Minimal re-renders, true reactivity, seamless integration with Tone.js — and it works smoothly with my MIDI player.

WARN: This is not a finished product — just a fast-learning draft to demonstrate how easily expressive, high-performance apps can be created without the typical overhead.

<img width="1093" alt="image" src="https://github.com/user-attachments/assets/e0db346b-13f5-421c-b027-be67413ba222" />

<img width="1150" alt="image" src="https://github.com/user-attachments/assets/7e992258-5b58-4e0b-8a6f-88a5312eaf8c" />
